### PR TITLE
LocalisedObject: catch uninitialiesed library and warn

### DIFF
--- a/Scripts/LocalisedObjects/AbstractLocalisedObject.cs
+++ b/Scripts/LocalisedObjects/AbstractLocalisedObject.cs
@@ -54,10 +54,16 @@ namespace DUCK.Localisation.LocalisedObjects
 
 		private void OnLocaleChanged()
 		{
-			var localisedText = "";
-			var foundtranslation = Localiser.GetLocalisedString(localisationKey, out localisedText);
-
-			HandleLocaleChanged(foundtranslation, localisedText);
+			if (Localiser.Initialised)
+			{
+				var localisedText = "";
+				var foundtranslation = Localiser.GetLocalisedString(localisationKey, out localisedText);
+				HandleLocaleChanged(foundtranslation, localisedText);
+			}
+			else
+			{
+				Debug.LogWarning("Cannot localise, the localiser is not initialised!");
+			}
 		}
 	}
 }


### PR DESCRIPTION
Before it would try grab the localisation from the `Localiser`. Which just throws if it's not initialized. Now we check first and warn if it's not initialized yet